### PR TITLE
allowFireSpread修复和改进

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ build
 eclipse
 run
 *.txt
+run_server
 

--- a/src/main/java/org/teacon/areacontrol/AreaControlEventHandlers.java
+++ b/src/main/java/org/teacon/areacontrol/AreaControlEventHandlers.java
@@ -218,17 +218,4 @@ public final class AreaControlEventHandlers {
             event.getAffectedEntities().clear();
         }
     }
-
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
-    public static void onLavaIgniteFire(BlockEvent.FluidPlaceBlockEvent event) {
-        if (event.getNewState().getBlock() == Blocks.FIRE) {
-            Area area = AreaManager.INSTANCE.findBy(event.getWorld(), event.getPos());
-            if (!AreaProperties.getBool(area, AreaProperties.ALLOW_FIRE_SPREAD)) {
-                // TODO This setNewState call is a workaround - the cancelling only prevents
-                //   other handlers from being called, not the new block state being set.
-                event.setNewState(event.getOriginalState());
-                event.setCanceled(true);
-            }
-        }
-    }
 }

--- a/src/main/java/org/teacon/areacontrol/api/AreaProperties.java
+++ b/src/main/java/org/teacon/areacontrol/api/AreaProperties.java
@@ -1,15 +1,17 @@
 package org.teacon.areacontrol.api;
 
+import javax.annotation.Nonnull;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 public final class AreaProperties {
 
-    /** 
+    /**
      * Set of area properties that are known by the AreaControl mod.
      * Adding a property to this Set is optional; it only enables command auto-completion.
      */
-    public static final Set<String> KNOWN_PROPERTIES = new HashSet<>();   
+    public static final Set<String> KNOWN_PROPERTIES = new HashSet<>();
 
     public static final String SHOW_WELCOME = register("area.display_welcome_message");
     public static final String ALLOW_SPAWN = register("area.allow_spawn");
@@ -27,7 +29,7 @@ public final class AreaProperties {
     public static final String ALLOW_EXPLOSION = register("area.allow_explosion");
     public static final String ALLOW_EXPLOSION_AFFECT_BLOCKS = register("area.allow_explosion_affect_blocks");
     public static final String ALLOW_EXPLOSION_AFFECT_ENTITIES = register("area.allow_explosion_affect_entities");
-    public static final String ALLOW_FIRE_SPREAD= register("area.allow_fire_spread");
+    public static final String ALLOW_FIRE_SPREAD = register("area.allow_fire_spread");
 
     static String register(String property) {
         KNOWN_PROPERTIES.add(property);
@@ -42,7 +44,25 @@ public final class AreaProperties {
         Object o = area.properties.get(key);
         if (o == null) {
             return false;
-        } else if (o instanceof Boolean) {
+        } else {
+            return getBool(o);
+        }
+    }
+
+    /**
+     * @return null if the property is not specified by AC, so you can seek it in gameRule.
+     */
+    public static Optional<Boolean> getBoolOptional(Area area, String key) {
+        Object o = area.properties.get(key);
+        if (o == null) {
+            return Optional.empty();
+        } else {
+            return Optional.of(getBool(o));
+        }
+    }
+
+    private static boolean getBool(@Nonnull Object o) {
+        if (o instanceof Boolean) {
             return (Boolean) o;
         } else if (o instanceof Number) {
             return ((Number) o).intValue() != 0;

--- a/src/main/java/org/teacon/areacontrol/mixin/FireMixin.java
+++ b/src/main/java/org/teacon/areacontrol/mixin/FireMixin.java
@@ -2,16 +2,19 @@ package org.teacon.areacontrol.mixin;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.block.FireBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.teacon.areacontrol.AreaManager;
 import org.teacon.areacontrol.api.Area;
 import org.teacon.areacontrol.api.AreaProperties;
 
+import java.util.Optional;
 import java.util.Random;
 
 @Mixin(FireBlock.class)
@@ -21,17 +24,12 @@ public class FireMixin {
      * Prepend an AreaControl check to determine whether fire tick should be stopped.
      * Note that this can also stop rain from extinguishing fire. Manually destroying
      * fire blocks is not affected.
-     * @param state Captured BlockState
-     * @param level Captured ServerLevel
-     * @param pos Captured BlockPos
-     * @param rand Captured Random
-     * @param ci The callback
+     * If allowFireSpread is not specified in the area, continue to use doFireTick in gameRule instead.
      */
-    @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;scheduleTick(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Block;I)V", shift = At.Shift.AFTER), cancellable = true)
-    private void fireSpreadCheck(BlockState state, ServerLevel level, BlockPos pos, Random rand, CallbackInfo ci) {
-        Area current = AreaManager.INSTANCE.findBy(level, pos);
-        if (!AreaProperties.getBool(current, "area.allow_fire_spread")) {
-            ci.cancel();
-        }
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/GameRules;getBoolean(Lnet/minecraft/world/level/GameRules$Key;)Z"))
+    private boolean fireSpreadCheck(GameRules instance, GameRules.Key<GameRules.BooleanValue> pKey, BlockState pState, ServerLevel pLevel, BlockPos pPos) {
+        Area area = AreaManager.INSTANCE.findBy(pLevel, pPos);
+        Optional<Boolean> allowFireSpread = AreaProperties.getBoolOptional(area, AreaProperties.ALLOW_FIRE_SPREAD);
+        return allowFireSpread.orElseGet(() -> pLevel.getGameRules().getBoolean(GameRules.RULE_DOFIRETICK));
     }
 }

--- a/src/main/java/org/teacon/areacontrol/mixin/LavaMixin.java
+++ b/src/main/java/org/teacon/areacontrol/mixin/LavaMixin.java
@@ -1,0 +1,36 @@
+package org.teacon.areacontrol.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.LavaFluid;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.teacon.areacontrol.AreaManager;
+import org.teacon.areacontrol.api.Area;
+import org.teacon.areacontrol.api.AreaProperties;
+
+import java.util.Optional;
+import java.util.Random;
+
+/**
+ * @author USS_Shenzhou
+ */
+@Mixin(LavaFluid.class)
+public class LavaMixin {
+
+    /**
+     * Prepend an AreaControl check to determine whether lava can perform random tick.
+     * If allowFireSpread is not specified in the area, continue to use doFireTick in gameRule instead.
+     */
+    @Inject(method = "randomTick", at = @At(value = "HEAD"), cancellable = true)
+    private void randomTickCheck(Level pLevel, BlockPos pPos, FluidState pState, Random pRandom, CallbackInfo ci) {
+        Area area = AreaManager.INSTANCE.findBy(pLevel, pPos);
+        Optional<Boolean> allowFireSpread = AreaProperties.getBoolOptional(area, AreaProperties.ALLOW_FIRE_SPREAD);
+        if (allowFireSpread.isPresent() && !allowFireSpread.get()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/org/teacon/areacontrol/mixin/LavaMixin.java
+++ b/src/main/java/org/teacon/areacontrol/mixin/LavaMixin.java
@@ -1,12 +1,14 @@
 package org.teacon.areacontrol.mixin;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.LavaFluid;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.teacon.areacontrol.AreaManager;
 import org.teacon.areacontrol.api.Area;
@@ -25,12 +27,10 @@ public class LavaMixin {
      * Prepend an AreaControl check to determine whether lava can perform random tick.
      * If allowFireSpread is not specified in the area, continue to use doFireTick in gameRule instead.
      */
-    @Inject(method = "randomTick", at = @At(value = "HEAD"), cancellable = true)
-    private void randomTickCheck(Level pLevel, BlockPos pPos, FluidState pState, Random pRandom, CallbackInfo ci) {
+    @Redirect(method = "randomTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/GameRules;getBoolean(Lnet/minecraft/world/level/GameRules$Key;)Z"))
+    private boolean randomTickCheck(GameRules instance, GameRules.Key<GameRules.BooleanValue> pKey, Level pLevel, BlockPos pPos) {
         Area area = AreaManager.INSTANCE.findBy(pLevel, pPos);
         Optional<Boolean> allowFireSpread = AreaProperties.getBoolOptional(area, AreaProperties.ALLOW_FIRE_SPREAD);
-        if (allowFireSpread.isPresent() && !allowFireSpread.get()) {
-            ci.cancel();
-        }
+        return allowFireSpread.orElseGet(() -> pLevel.getGameRules().getBoolean(GameRules.RULE_DOFIRETICK));
     }
 }

--- a/src/main/resources/area_control.mixins.json
+++ b/src/main/resources/area_control.mixins.json
@@ -6,7 +6,8 @@
   "refmap": "area_control.refmap.json",
   "mixins": [
     "EntityMixin",
-    "FireMixin"
+    "FireMixin",
+    "LavaMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
1 岩浆点火修复：原版先进行`GameRule`判断，之后才会有`fireFluidPlaceBlockEvent`，故只能在`randomTick`开头mixin；
2 当AC没有对区域指定`allowFireSpread`时，使用`GameRule`结果；反之使用AC结果。